### PR TITLE
update feedstock to version 1.0.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "j6s" %}
-{% set version = "1.0.0" %}
+{% set version = "1.0.1" %}
 
 package:
   name: {{ name }}
@@ -10,7 +10,7 @@ source:
   sha256: ee822ccdb53cb1d0dc8949ba7ddadb5f27adf1ec815b6541b274966409363364
 
 build:
-  number: 1
+  number: 0
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/raphidoc/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: ee822ccdb53cb1d0dc8949ba7ddadb5f27adf1ec815b6541b274966409363364
+  sha256: 71247c06492914fa15a20ca943d6fe57559fd6e3ab043af56951498010eb9222
 
 build:
   number: 0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fixes nasa/HyperCP#339 

<!--
Please add any other relevant info below:
-->

It improves `sixs_json` executable path finding. First, look in CONDA_PREFIX, and fall back to `shutil.which` PATH search.